### PR TITLE
Change dockerhub's tag for branch's name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ jobs:
         - docker
       script: |
         export IMAGE_NAME=webmole/crawler-benchmark
-        docker build . -t $IMAGE_NAME:$TRAVIS_COMMIT
+        docker build . -t $IMAGE_NAME:$TRAVIS_BRANCH
         if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
           docker login -u $REGISTRY_USER -p $REGISTRY_PASS
-          docker push "${IMAGE_NAME}:${TRAVIS_COMMIT}"
+          docker push "${IMAGE_NAME}:${TRAVIS_BRANCH}"
           if [ "$TRAVIS_BRANCH" == "master" ]; then
-            docker tag $IMAGE_NAME:$TRAVIS_COMMIT $IMAGE_NAME:latest
+            docker tag $IMAGE_NAME:$TRAVIS_BRANCH $IMAGE_NAME:latest
             docker push "${IMAGE_NAME}:latest"
           fi
         fi


### PR DESCRIPTION
Tags on Dockerhub will be the branches' name instead of the last commit's id.